### PR TITLE
Minimal HTML document with title

### DIFF
--- a/Opera/extension/index.html
+++ b/Opera/extension/index.html
@@ -1,2 +1,4 @@
+<!doctype hml>
+<title>GitHub Notifier</title>
 <script src="api.js"></script>
 <script src="main.js"></script>

--- a/Opera/extension/index.html
+++ b/Opera/extension/index.html
@@ -1,4 +1,4 @@
-<!doctype hml>
+<!doctype html>
 <title>GitHub Notifier</title>
 <script src="api.js"></script>
 <script src="main.js"></script>


### PR DESCRIPTION
Include a title so Opera’s internals can display a sensible title for the extension and it’s background processes. Visible in opera:cpu, Dragonfly developer tolls, etc.
Mets the minimal HTML5 document requirements.
