### PR TITLE
Chrome badge update

### DIFF
--- a/chrome/extension/main.js
+++ b/chrome/extension/main.js
@@ -19,6 +19,9 @@
 	function update() {
 		gitHubNotifCount(function (count) {
 			if (count !== false) {
+				if (count > 9999) {
+					count = '∞';
+				}
 				render(count, [65, 131, 196, 255], 'GitHub Notifier');
 			} else {
 				render(':(', [166, 41, 41, 255], 'You have to be connected to the internet and logged into GitHub');

--- a/chrome/extension/main.js
+++ b/chrome/extension/main.js
@@ -24,7 +24,7 @@
 				}
 				render(count, [65, 131, 196, 255], 'GitHub Notifier');
 			} else {
-				render(':(', [166, 41, 41, 255], 'You have to be connected to the internet and logged into GitHub');
+				render('?', [166, 41, 41, 255], 'You have to be connected to the internet and logged into GitHub');
 			}
 		});
 	}


### PR DESCRIPTION
Capped count at 9999 before displaying infinity symbol as per chrome guidelines (only display 4 characters).
Smiley removed to be more descriptive when no connection to GitHub is present. 
