### PR TITLE
Add support for custom notification URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "chrome-bootstrap"]
+	path = chrome-bootstrap
+	url = https://github.com/roykolak/chrome-bootstrap.git
+[submodule "chrome/extension/chrome-bootstrap"]
+	path = chrome/extension/chrome-bootstrap
+	url = https://github.com/roykolak/chrome-bootstrap.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "chrome-bootstrap"]
-	path = chrome-bootstrap
-	url = https://github.com/roykolak/chrome-bootstrap.git
 [submodule "chrome/extension/chrome-bootstrap"]
 	path = chrome/extension/chrome-bootstrap
 	url = https://github.com/roykolak/chrome-bootstrap.git

--- a/chrome/extension/api.js
+++ b/chrome/extension/api.js
@@ -1,7 +1,8 @@
+/*globals GitHubNotify:true */
 (function () {
 	'use strict';
 
-	var xhr = function () {
+	var xhr = (function () {
 		var xhr = new XMLHttpRequest();
 		return function(method, url, callback) {
 			xhr.onreadystatechange = function () {
@@ -12,29 +13,30 @@
 			xhr.open(method, url);
 			xhr.send();
 		};
-	}();
+	})();
 
 	window.GitHubNotify = (function(){
-		var self;
 		var defaults = {
-			notification_url: 'http://github.com/notifications'
+			notificationUrl: 'http://github.com/notifications'
 		};
-		return self = {
-			settings: {
-				get: function (name) {
-					var item = localStorage.getItem(name);
-					return item == null ? ({}.hasOwnProperty.call(defaults, name) ? defaults[name] : void 0) : item;
-				},
-				set: localStorage.setItem.bind(localStorage),
-				reset: function () {
-					Object.keys(localStorage).forEach(self.settings.revert);
-				},
-				revert: localStorage.removeItem.bind(localStorage)
-			}
-	}})();
+		var api = {
+                settings: {
+                    get: function (name) {
+                        var item = localStorage.getItem(name);
+                        return item === null ? ({}.hasOwnProperty.call(defaults, name) ? defaults[name] : void 0) : item;
+                    },
+                    set: localStorage.setItem.bind(localStorage),
+                    reset: function () {
+                        Object.keys(localStorage).forEach(api.settings.revert);
+                    },
+                    revert: localStorage.removeItem.bind(localStorage)
+                }
+	        };
+        return api;
+    })();
 
 	window.gitHubNotifCount = function (callback) {
-		var NOTIFICATIONS_URL = GitHubNotify.settings.get('notification_url');
+		var NOTIFICATIONS_URL = GitHubNotify.settings.get('notificationUrl');
 		var tmp = document.createElement('div');
 
 		xhr('GET', NOTIFICATIONS_URL, function (data) {

--- a/chrome/extension/api.js
+++ b/chrome/extension/api.js
@@ -14,8 +14,33 @@
 		};
 	}();
 
+	window.GitHubNotify = {
+		settings: {
+			defaults: {
+				'notification_url': 'http://github.com/notifications'
+			},
+			get: function (name) {
+				return window.localStorage.getItem(name) ? window.localStorage.getItem(name) : this.defaults[name];
+			},
+			set: function (name, value) {
+				return window.localStorage.setItem(name, value);
+			},
+			reset: function () {
+				return this.revert('notification_url');
+			},
+			revert: function (name) {
+				return window.localStorage.removeItem(name);
+			},
+			restore: {
+				text: function (element, name) {
+					return element.value = GitHubNotify.settings.get(name);
+				}
+			}
+		}
+	};
+
 	window.gitHubNotifCount = function (callback) {
-		var NOTIFICATIONS_URL = 'https://github.com/notifications';
+		var NOTIFICATIONS_URL = GitHubNotify.settings.get('notification_url')
 		var tmp = document.createElement('div');
 
 		xhr('GET', NOTIFICATIONS_URL, function (data) {

--- a/chrome/extension/api.js
+++ b/chrome/extension/api.js
@@ -14,33 +14,28 @@
 		};
 	}();
 
-	window.GitHubNotify = {
-		settings: {
-			defaults: {
-				'notification_url': 'http://github.com/notifications'
-			},
-			get: function (name) {
-				return window.localStorage.getItem(name) ? window.localStorage.getItem(name) : this.defaults[name];
-			},
-			set: function (name, value) {
-				return window.localStorage.setItem(name, value);
-			},
-			reset: function () {
-				return this.revert('notification_url');
-			},
-			revert: function (name) {
-				return window.localStorage.removeItem(name);
-			},
-			restore: {
-				text: function (element, name) {
-					return element.value = GitHubNotify.settings.get(name);
-				}
+	window.GitHubNotify = (function(){
+		var self;
+		var defaults = {
+			notification_url: 'http://github.com/notifications'
+		};
+		return self = {
+			settings: {
+				get: function (name) {
+					var item = localStorage.getItem(name);
+					return item == null ? ({}.hasOwnProperty.call(defaults, name) ? defaults[name] : void 0) : item;
+				},
+				set: localStorage.setItem.bind(localStorage),
+				reset: function () {
+					Object.keys(localStorage).forEach(self.revert);
+				},
+				revert: localStorage.removeItem.bind(localStorage)
 			}
-		}
-	};
+	}})();
+
 
 	window.gitHubNotifCount = function (callback) {
-		var NOTIFICATIONS_URL = GitHubNotify.settings.get('notification_url')
+		var NOTIFICATIONS_URL = GitHubNotify.settings.get('notification_url');
 		var tmp = document.createElement('div');
 
 		xhr('GET', NOTIFICATIONS_URL, function (data) {

--- a/chrome/extension/api.js
+++ b/chrome/extension/api.js
@@ -27,12 +27,11 @@
 				},
 				set: localStorage.setItem.bind(localStorage),
 				reset: function () {
-					Object.keys(localStorage).forEach(self.revert);
+					Object.keys(localStorage).forEach(self.settings.revert);
 				},
 				revert: localStorage.removeItem.bind(localStorage)
 			}
 	}})();
-
 
 	window.gitHubNotifCount = function (callback) {
 		var NOTIFICATIONS_URL = GitHubNotify.settings.get('notification_url');

--- a/chrome/extension/api.js
+++ b/chrome/extension/api.js
@@ -4,7 +4,7 @@
 
 	var xhr = (function () {
 		var xhr = new XMLHttpRequest();
-		return function(method, url, callback) {
+		return function (method, url, callback) {
 			xhr.onreadystatechange = function () {
 				if (xhr.readyState === 4) {
 					callback(xhr.responseText);
@@ -15,25 +15,25 @@
 		};
 	})();
 
-	window.GitHubNotify = (function(){
+	window.GitHubNotify = (function () {
 		var defaults = {
 			notificationUrl: 'http://github.com/notifications'
 		};
 		var api = {
-                settings: {
-                    get: function (name) {
-                        var item = localStorage.getItem(name);
-                        return item === null ? ({}.hasOwnProperty.call(defaults, name) ? defaults[name] : void 0) : item;
-                    },
-                    set: localStorage.setItem.bind(localStorage),
-                    reset: function () {
-                        Object.keys(localStorage).forEach(api.settings.revert);
-                    },
-                    revert: localStorage.removeItem.bind(localStorage)
-                }
-	        };
-        return api;
-    })();
+			settings: {
+				get: function (name) {
+					var item = localStorage.getItem(name);
+					return item === null ? ({}.hasOwnProperty.call(defaults, name) ? defaults[name] : void 0) : item;
+				},
+				set: localStorage.setItem.bind(localStorage),
+				reset: function () {
+					Object.keys(localStorage).forEach(api.settings.revert);
+				},
+				revert: localStorage.removeItem.bind(localStorage)
+			}
+		};
+		return api;
+	})();
 
 	window.gitHubNotifCount = function (callback) {
 		var NOTIFICATIONS_URL = GitHubNotify.settings.get('notificationUrl');

--- a/chrome/extension/main.js
+++ b/chrome/extension/main.js
@@ -1,4 +1,4 @@
-/*globals chrome:true, gitHubNotifCount:true */
+/*globals chrome:true, gitHubNotifCount:true, GitHubNotify:true */
 (function () {
 	'use strict';
 
@@ -31,7 +31,7 @@
 
 	chrome.browserAction.onClicked.addListener(function () {
 		chrome.tabs.create({
-			url: 'https://github.com/notifications'
+			url: GitHubNotify.settings.get('notification_url')
 		});
 	});
 

--- a/chrome/extension/main.js
+++ b/chrome/extension/main.js
@@ -34,7 +34,7 @@
 
 	chrome.browserAction.onClicked.addListener(function () {
 		chrome.tabs.create({
-			url: GitHubNotify.settings.get('notification_url')
+			url: GitHubNotify.settings.get('notificationUrl')
 		});
 	});
 

--- a/chrome/extension/manifest.json
+++ b/chrome/extension/manifest.json
@@ -11,9 +11,9 @@
 	},
 	"permissions": [
 		"alarms",
-		"tabs",
-		"*://*/*"
+        "*://github.com/"
 	],
+    "optional_permissions": ["*://*/"],
 	"browser_action": {
 		"default_icon": "icon-19.png"
 	},

--- a/chrome/extension/manifest.json
+++ b/chrome/extension/manifest.json
@@ -12,7 +12,7 @@
 	"permissions": [
 		"alarms",
 		"tabs",
-		"https://github.com/"
+		"*://*/*"
 	],
 	"browser_action": {
 		"default_icon": "icon-19.png"
@@ -23,5 +23,6 @@
 		"128": "icon-128.png"
 	},
 	"minimum_chrome_version": "28",
-	"manifest_version": 2
+	"manifest_version": 2,
+	"options_page": "options.html"
 }

--- a/chrome/extension/options.html
+++ b/chrome/extension/options.html
@@ -38,7 +38,7 @@
             <div class="content">
                 <h2>Custom URL</h2>
 
-                <p>Specify the URL to retrieve notifications from.</p>
+                <p>If you have a enterprise installation please specify the notification URL.</p>
                 <label for="notification_url">Notification URL</label>
                 <input type="text" id="notification_url"/>
                 <br/>

--- a/chrome/extension/options.html
+++ b/chrome/extension/options.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>GitHub Notifier</title>
+    <link rel="stylesheet" type="text/css" href="chrome-bootstrap/chrome-bootstrap.css"/>
+    <style type="text/css">
+        .chrome-bootstrap .frame .view {
+            -webkit-margin-start: 170px
+        }
+
+        .chrome-bootstrap select,
+        .chrome-bootstrap input[type='checkbox'],
+        .chrome-bootstrap input[type='radio'],
+        .chrome-bootstrap input[type='button'],
+        .chrome-bootstrap button {
+            margin-top: 10px
+        }
+    </style>
+    <script type="text/javascript" src="api.js"></script>
+    <script type="text/javascript" src="options.js"></script>
+</head>
+<body class="chrome-bootstrap">
+<div class="frame">
+    <div class="navigation">
+        <h1><a href="https://github.com/sindresorhus/GitHub-Notifier">GitHub Notifier</a></h1>
+        <ul class="menu">
+            <li class="selected">
+                <a href="#notifications">Notifications</a>
+            </li>
+        </ul>
+    </div>
+    <div class="mainview view">
+        <div id="settings" class="selected">
+            <header>
+                <h1>Notifications</h1>
+            </header>
+            <div class="content">
+                <h2>Custom URL</h2>
+
+                <p>Specify the URL to retrieve notifications from.</p>
+                <label for="notification_url">Notification URL</label>
+                <input type="text" id="notification_url"/>
+                <br/>
+                <button id="save">Save</button>
+                <button id="reset">Reset to Default</button>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/chrome/extension/options.js
+++ b/chrome/extension/options.js
@@ -2,7 +2,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	var form_notification_url = document.getElementById('notification_url');
 
 	function loadSettings(){
-		form_notification_url.value = GithubNotify.settings.get('notification_url');
+		form_notification_url.value = GitHubNotify.settings.get('notification_url');
 	}
 
 	loadSettings();

--- a/chrome/extension/options.js
+++ b/chrome/extension/options.js
@@ -1,18 +1,36 @@
-document.addEventListener('DOMContentLoaded', function () {
-	var form_notification_url = document.getElementById('notification_url');
+/*globals chrome:true, GitHubNotify:true */
+(function () {
+    'use strict';
+    document.addEventListener('DOMContentLoaded', function () {
+        var formNotificationUrl = document.getElementById('notification_url');
 
-	function loadSettings(){
-		form_notification_url.value = GitHubNotify.settings.get('notification_url');
-	}
+        function loadSettings() {
+            formNotificationUrl.value = GitHubNotify.settings.get('notificationUrl');
+        }
 
-	loadSettings();
+        loadSettings();
 
-	document.getElementById('save').addEventListener('click', function () {
-		GitHubNotify.settings.set('notification_url', form_notification_url.value);
-	});
+        document.getElementById('save').addEventListener('click', function () {
+            chrome.permissions.request({
+                origins: [formNotificationUrl.value]
+            }, function (granted) {
+                if (granted) {
+                    chrome.permissions.remove({
+                        origins: [GitHubNotify.settings.get('notificationUrl')]
+                    });
+                    GitHubNotify.settings.set('notificationUrl', formNotificationUrl.value);
+                } else {
+                    loadSettings();
+                }
+            });
+        });
 
-	document.getElementById('reset').addEventListener('click', function () {
-		GitHubNotify.settings.reset();
-		loadSettings();
-	});
-});
+        document.getElementById('reset').addEventListener('click', function () {
+            chrome.permissions.remove({
+                origins: [GitHubNotify.settings.get('notificationUrl')]
+            });
+            GitHubNotify.settings.reset();
+            loadSettings();
+        });
+    });
+}());

--- a/chrome/extension/options.js
+++ b/chrome/extension/options.js
@@ -1,36 +1,36 @@
 /*globals chrome:true, GitHubNotify:true */
 (function () {
-    'use strict';
-    document.addEventListener('DOMContentLoaded', function () {
-        var formNotificationUrl = document.getElementById('notification_url');
+	'use strict';
+	document.addEventListener('DOMContentLoaded', function () {
+		var formNotificationUrl = document.getElementById('notification_url');
 
-        function loadSettings() {
-            formNotificationUrl.value = GitHubNotify.settings.get('notificationUrl');
-        }
+		function loadSettings() {
+			formNotificationUrl.value = GitHubNotify.settings.get('notificationUrl');
+		}
 
-        loadSettings();
+		loadSettings();
 
-        document.getElementById('save').addEventListener('click', function () {
-            chrome.permissions.request({
-                origins: [formNotificationUrl.value]
-            }, function (granted) {
-                if (granted) {
-                    chrome.permissions.remove({
-                        origins: [GitHubNotify.settings.get('notificationUrl')]
-                    });
-                    GitHubNotify.settings.set('notificationUrl', formNotificationUrl.value);
-                } else {
-                    loadSettings();
-                }
-            });
-        });
+		document.getElementById('save').addEventListener('click', function () {
+			chrome.permissions.request({
+				origins: [formNotificationUrl.value]
+			}, function (granted) {
+				if (granted) {
+					chrome.permissions.remove({
+						origins: [GitHubNotify.settings.get('notificationUrl')]
+					});
+					GitHubNotify.settings.set('notificationUrl', formNotificationUrl.value);
+				} else {
+					loadSettings();
+				}
+			});
+		});
 
-        document.getElementById('reset').addEventListener('click', function () {
-            chrome.permissions.remove({
-                origins: [GitHubNotify.settings.get('notificationUrl')]
-            });
-            GitHubNotify.settings.reset();
-            loadSettings();
-        });
-    });
-}());
+		document.getElementById('reset').addEventListener('click', function () {
+			chrome.permissions.remove({
+				origins: [GitHubNotify.settings.get('notificationUrl')]
+			});
+			GitHubNotify.settings.reset();
+			loadSettings();
+		});
+	});
+})();

--- a/chrome/extension/options.js
+++ b/chrome/extension/options.js
@@ -1,7 +1,11 @@
 document.addEventListener('DOMContentLoaded', function () {
 	var form_notification_url = document.getElementById('notification_url');
 
-	GitHubNotify.settings.restore.text(form_notification_url, 'notification_url');
+	function loadSettings(){
+		form_notification_url.value = GithubNotify.settings.get('notification_url');
+	}
+
+	loadSettings();
 
 	document.getElementById('save').addEventListener('click', function () {
 		GitHubNotify.settings.set('notification_url', form_notification_url.value);
@@ -9,6 +13,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
 	document.getElementById('reset').addEventListener('click', function () {
 		GitHubNotify.settings.reset();
-		GitHubNotify.settings.restore.text(form_notification_url, 'notification_url');
+		loadSettings();
 	});
 });

--- a/chrome/extension/options.js
+++ b/chrome/extension/options.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', function () {
+	var form_notification_url = document.getElementById('notification_url');
+
+	GitHubNotify.settings.restore.text(form_notification_url, 'notification_url');
+
+	document.getElementById('save').addEventListener('click', function () {
+		GitHubNotify.settings.set('notification_url', form_notification_url.value);
+	});
+
+	document.getElementById('reset').addEventListener('click', function () {
+		GitHubNotify.settings.reset();
+		GitHubNotify.settings.restore.text(form_notification_url, 'notification_url');
+	});
+});


### PR DESCRIPTION
Users can now configure options for the extension. Options are stored in a globally accessible 'API' wrapper to allow for future additions.

Options added
- Custom notification URL (adds support for GitHub Enterprise, Fixes #16)
